### PR TITLE
Be able to override the destination dbaas operator namespace from the command line

### DIFF
--- a/shared-to-shared-migrate-k8s-mydumper.sh
+++ b/shared-to-shared-migrate-k8s-mydumper.sh
@@ -33,6 +33,7 @@ set -euo pipefail
 
 # Initialize our own variables:
 DESTINATION_PROVIDER=""
+DESTINATION_DBAAS_OPERATOR_NAMESPACE="dbaas-operator"
 NAMESPACE=""
 CONSUMER="mariadb"
 DRY_RUN=""
@@ -78,6 +79,11 @@ while [[ $# -gt 0 ]] ; do
     shift # past argument
     shift # past value
     ;;
+    -o|--operator)
+    DESTINATION_DBAAS_OPERATOR_NAMESPACE="$2"
+    shift # past argument
+    shift # past value
+    ;;
     -n|--namespace)
     NAMESPACE="$2"
     shift # past argument
@@ -103,6 +109,7 @@ shw_grey "================================================"
 shw_grey " START_TIMESTAMP='$(date +%Y-%m-%dT%H:%M:%S%z)'"
 shw_grey "================================================"
 shw_grey " DESTINATION_PROVIDER=$DESTINATION_PROVIDER"
+shw_grey " DESTINATION_DBAAS_OPERATOR_NAMESPACE=$DESTINATION_DBAAS_OPERATOR_NAMESPACE"
 shw_grey " CONSUMER=$CONSUMER"
 shw_grey " NAMESPACE=$NAMESPACE"
 shw_grey "================================================"
@@ -144,7 +151,7 @@ shw_grey " DB_PORT=$DB_PORT"
 shw_grey "================================================"
 
 # Load the destination credentials from the dbaas-operator.
-PROVIDER=$(kubectl -n dbaas-operator get MariaDBProvider "$DESTINATION_PROVIDER" --output=json | jq '.spec')
+PROVIDER=$(kubectl -n "$DESTINATION_DBAAS_OPERATOR_NAMESPACE" get MariaDBProvider "$DESTINATION_PROVIDER" --output=json | jq '.spec')
 PROVIDER_ENVIRONMENT=$(echo "$PROVIDER" | jq -er '.environment')
 PROVIDER_USER=$(echo "$PROVIDER" | jq -er '.user')
 PROVIDER_PASSWORD=$(echo "$PROVIDER" | jq -er '.password')

--- a/shared-to-shared-migrate-k8s-mydumper.sh
+++ b/shared-to-shared-migrate-k8s-mydumper.sh
@@ -175,7 +175,7 @@ if [ -z "$POD" ]; then
 	shw_info "No running mydumper pod in namespace $NAMESPACE"
 	shw_info "Creating MyDumper"
   kubectl -n "$NAMESPACE" create deploy --image=schnitzel/docker-mydumper mydumper -- sh -c 'while sleep 3600; do :; done'
-	sleep 60 # hope for timely scheduling
+  kubectl -n "$NAMESPACE" wait deploy/mydumper --for condition=available --timeout=300s
 	POD=$(kubectl -n "$NAMESPACE" get pods -o json --field-selector=status.phase=Running -l app=mydumper | jq -er '.items[0].metadata.name')
 fi
 


### PR DESCRIPTION
The namespace may not always be `dbaas-operator`. In our case, it was just `lagoon`.